### PR TITLE
omnibox-17

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,8 @@
 {
   "name": "Fluidinfo",
-  "version": "1.1.121",
+  "version": "1.1.310",
   "description": "Use Fluidinfo to tag URLs in interesting ways, and jump to Fluidinfo pages for them and for text selections.",
+  "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",
   "options_page": "options.html",
   "permissions": [


### PR DESCRIPTION
paparent:**approve**

Adds an 'omnibox' that is triggered when the user types `fi SPACE` into the location bar. If you're logged in, it will recognize if you're typing your username or @username and suggest that to you. Otherwise you can just jump directly to the object in Fluidinfo for whatever it is you're typing.

Note that the "Search" part of the text "Fluidinfo Search" that appears in the suggestions cannot be changed by us. Google apparently never heard of a Thing Engine.

Fixes #17
