### PR TITLE
display-friends-tags-22

### DIFF
--- a/jquery.rating.css
+++ b/jquery.rating.css
@@ -1,8 +1,8 @@
 /* jQuery.Rating Plugin CSS - http://www.fyneworks.com/jquery/star-rating/ */
-div.rating-cancel,div.star-rating{float:left;width:17px;height:15px;text-indent:-999em;cursor:pointer;display:block;background:transparent;overflow:hidden}
+div.rating-cancel,div.star-rating{width:17px;height:15px;text-indent:-999em;cursor:pointer;display:inline;background:transparent;overflow:hidden}
 div.rating-cancel,div.rating-cancel a{background:url("delete.gif") no-repeat 0 -16px}
 div.star-rating,div.star-rating a{background:url("star.gif") no-repeat 0 0px}
-div.rating-cancel a,div.star-rating a{display:block;width:16px;height:100%;background-position:0 0px;border:0}
+div.rating-cancel a,div.star-rating a{display:inline;width:16px;height:100%;background-position:0 0px;border:0}
 div.star-rating-on a{background-position:0 -16px!important}
 div.star-rating-hover a{background-position:0 -32px}
 /* Read Only CSS */

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.1.398",
+  "version": "1.2.65",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.2.65",
+  "version": "1.2.68",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/notification.css
+++ b/notification.css
@@ -55,7 +55,7 @@ a {
 }
 
 .tagDisplay {
-    padding: 8px;
+    padding: 6px;
     border: 1px solid #6fd5fa;
     -webkit-border-radius: 13px;
     -webkit-border-top-right-radius: 5px;
@@ -78,8 +78,6 @@ a {
 /* To run booleans and numbers on a single line */
 .tagName{
     margin-top: -2px;
-    padding-right: 4px;
     padding-bottom: 4px;
     font-weight: bold;
-    padding-right: 8px;
 }

--- a/notification.html
+++ b/notification.html
@@ -15,14 +15,14 @@
     <script type="text/javascript" src="notification.js"></script>
   </head>
   <body>
-    <img id="logo" src="fi_32.png"/>
+    <img id="logo" src="fi_19.png"/>
     <p id="fi_notification_intro">
-      <span id="fi_url_external">URL</span><br/>
-      <span id="fi_url_internal">This page in Fluidinfo</span>
+      <span id="fi_title">Your info for</span>:
+      <br/>
+      <span id="fi_url">URL</span><br/>
     </p>
     <p>
-      Your info for this page:
-      <div id="fi_yourtags"></div>
+      <div id="fi_tags"></div>
     </p>
   </body>
 </html>

--- a/notification.js
+++ b/notification.js
@@ -1,33 +1,49 @@
 var populate = function(options){
     /*
-     * options contains wantedTags, valuesCache
+     * options contains dropNamespaces, title, url, valuesCache, wantedTags
      */
-    document.getElementById('fi_url_external').innerHTML = Mustache.render(
-        '<a href="{{url}}" target="_blank">{{url}}</a>', {
-            url: options.url
+    var url = options.url;
+
+    var truncatedURL;
+    if (url.length > 48){
+        truncatedURL = url.slice(0, 48) + '...';
+    }
+    else {
+        truncatedURL = url;
+    }
+
+    // Chop off useless https?:// prefix.
+    var match = truncatedURL.indexOf('://');
+    if (match > -1){
+        truncatedURL = truncatedURL.slice(match + 3);
+    }
+
+    document.getElementById('fi_url').innerHTML = Mustache.render(
+        '<a href="{{url}}" target="_blank">{{truncatedURL}}</a>', {
+            truncatedURL: truncatedURL,
+            url: url
         }
     );
-    document.getElementById('fi_url_internal').innerHTML = Mustache.render(
-        '<a href="{{url}}" target="_blank">This page in Fluidinfo</a>', {
-            url: 'http://fluidinfo.com/about/#!/' + encodeURIComponent(options.url)
+    document.getElementById('fi_title').innerHTML = Mustache.render(
+        '{{title}}', {
+            title: options.title
         }
     );
 
     try {
         var content = valueUtils.pathsAndValuesToHTML({
             displayImages: false,
-            dropNamespaces: true,
+            dropNamespaces: options.dropNamespaces,
             fetchLinks: false,
             linkTags: true,
             result: { data: options.valuesCache.cache },
             showTagPaths: true,
             tagPaths: options.wantedTags
         });
-        document.getElementById('fi_yourtags').innerHTML = content.content;
+        document.getElementById('fi_tags').innerHTML = content.content;
     }
     catch (error){
         console.log('Hit an error rendering tag values.');
         console.log(error.message);
-        document.getElementById('fi_yourtags').innerHTML = error.message;
     }
 };

--- a/values.js
+++ b/values.js
@@ -311,10 +311,10 @@ var valueUtils = {
                 '<span class="tagName">');
 
             if (options.linkTags){
-                template += '<a target="_blank" class="taglink" href="http://fluidinfo.com/about/#!/{{encodedPath}}/tagged_objects">{{path}}:</a>';
+                template += '<a target="_blank" class="taglink" href="http://fluidinfo.com/about/#!/{{encodedPath}}/tagged_objects">{{path}}{{#possibleColon}}{{{value}}}{{/possibleColon}}</a>';
             }
             else {
-                template += '{{path}}:';
+                template += '{{path}}{{#possibleColon}}{{{value}}}{{/possibleColon}}';
             }
 
             template += '</span>'; // Tag name
@@ -323,9 +323,7 @@ var valueUtils = {
                 template += '<span class="timestamp">{{timestamp}}</span>';
             }
 
-            template += ('</div>' +
-                         '<div class="tagAndValue">{{{value}}}</div>'
-            );
+            template += '{{#valueSection}}{{{value}}}{{/valueSection}}';
 
             template += ('</div>' + // tagDisplay
                          '</div>' // tagItem
@@ -341,7 +339,22 @@ var valueUtils = {
             callbacks: callbacks,
             content: Mustache.to_html(template, {
                 data: pathsAndValues,
-                bullet: "tagBullet.png"
+                bullet: 'tagBullet.png',
+                possibleColon: function(){
+                    return function(value, render){
+                        return render(value === '' ? '' : ':');
+                    };
+                },
+                valueSection: function(){
+                    return function(value, render){
+                        if (value.slice(0, 3) === '<ul'){
+                            return render('</div><div class="tagAndValue">' + value + '</div>');
+                        }
+                        else {
+                            return render(' ' + value + '</div>');
+                        }
+                    };
+                }
             })
         };
     },
@@ -360,7 +373,7 @@ var valueUtils = {
             if (rating >= k) {
                 out += ' star-rating-hover';
             }
-            out += '"><a title="on">on</a></div>';
+            out += '"><a style="font-size: 15px;" title="on">&nbsp;&nbsp;&nbsp;&nbsp;</a></div>';
         }
 
         return out;


### PR DESCRIPTION
paparent:*_approved_

Show a notification popup with friends' tags for the current URL.

To test, put a yourname/follows tag onto the objects for `@rustlem` and `@terrycojones`, then visit `http://brooklynstartup.com/?p=129` and you should see Russell and my tags show up in a popup. Add some tags yourself and reload. You should now see two popups.

Fixes #22
