### PR TITLE
popups-for-text-selections-24

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.2.68",
+  "version": "1.2.87",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/notification.js
+++ b/notification.js
@@ -2,7 +2,6 @@ var populate = function(options){
     /*
      * options contains about, dropNamespaces, title, valuesCache, wantedTags
      */
-    console.log(options);
     var about = options.about;
 
     var truncatedAbout;

--- a/notification.js
+++ b/notification.js
@@ -1,26 +1,34 @@
 var populate = function(options){
     /*
-     * options contains dropNamespaces, title, url, valuesCache, wantedTags
+     * options contains about, dropNamespaces, title, valuesCache, wantedTags
      */
-    var url = options.url;
+    console.log(options);
+    var about = options.about;
 
-    var truncatedURL;
-    if (url.length > 48){
-        truncatedURL = url.slice(0, 48) + '...';
+    var truncatedAbout;
+    if (about.length > 48){
+        truncatedAbout = about.slice(0, 48) + '...';
     }
     else {
-        truncatedURL = url;
+        truncatedAbout = about;
     }
 
-    // Chop off useless https?:// prefix.
-    var match = truncatedURL.indexOf('://');
-    if (match > -1){
-        truncatedURL = truncatedURL.slice(match + 3);
+    var url;
+    if (valueUtils.isLink(about)){
+        url = about;
+        // Chop off useless https?:// prefix.
+        var match = truncatedAbout.indexOf('://');
+        if (match > -1 && match < 6){
+            truncatedAbout = truncatedAbout.slice(match + 3);
+        }
+    }
+    else {
+        url = 'http://fluidinfo.com/about/#!/' + encodeURIComponent(about);
     }
 
     document.getElementById('fi_url').innerHTML = Mustache.render(
-        '<a href="{{url}}" target="_blank">{{truncatedURL}}</a>', {
-            truncatedURL: truncatedURL,
+        '<a href="{{url}}" target="_blank">{{truncatedAbout}}</a>', {
+            truncatedAbout: truncatedAbout,
             url: url
         }
     );


### PR DESCRIPTION
paparent:**approved**

Popup notifications for selected text, both for the user's tags and for those from followees. Done for both the original text and the lower case version, depending on the options settings.

Note that quite a lot of the diff here is just factoring out the notification popup code into its own function so I can call it both from the listener for new tabs and also from the code that gets the message from the content script with selection information.

Fixes #24
