### PR TITLE
content-script-to-reopen-port-48

### DIFF
--- a/background.js
+++ b/background.js
@@ -227,11 +227,12 @@ var removeSelectionNotifications = function(){
 };
 
 
-// Listen for incoming messages with events (link mouseover, link
-// mouseout, selection set/cleared), and update the context menu.
+// Listen for incoming messages from the content script with events
+// (link mouseover, link mouseout, selection set/cleared), and
+// update the context menu.
 
 chrome.extension.onConnect.addListener(function(port){
-    if (port.name === 'context'){
+    if (port.name === 'content-script'){
         port.onMessage.addListener(function(msg){
             if (typeof msg.selection !== 'undefined'){
                 if (currentSelection === null || msg.selection !== currentSelection){

--- a/background.js
+++ b/background.js
@@ -874,3 +874,19 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
         });
     }
 });
+
+
+// Inject our content script into existing tabs, skipping chrome's own
+// tabs (trying to inject into them gives a console error message).
+
+chrome.tabs.query({}, function(tabs){
+    for (var i = 0; i < tabs.length; i++){
+        var tab = tabs[i];
+        if (tab.url.slice(0, 9) !== 'chrome://' &&
+            tab.url.slice(0, 18) !== 'chrome-devtools://'){
+            chrome.tabs.executeScript(tab.id, {
+                file: 'content.js'
+            });
+        }
+    }
+});

--- a/content.js
+++ b/content.js
@@ -1,25 +1,16 @@
 var port = chrome.extension.connect({name: 'content-script'});
 
-var postMessage = function(msg, attempt){
-    attempt = attempt || 1;
-    if (attempt > 10){
-        console.log('Could not send message after 10 attempts. Giving up.');
-        console.log(msg);
-        return;
-    }
+var postMessage = function(msg){
     try {
         port.postMessage(msg);
     }
     catch(error){
-        var retry = function(){
-            // Note that the extension may have been disabled. In which case
-            // chrome.extension.connect logs a console error. Putting
-            // a try/catch around it doesn't help.
-            port = chrome.extension.connect({name: 'content-script'});
-            postMessage(msg, attempt + 1);
-        };
-
-        setTimeout(retry, 100);
+        // Note that the extension may have been disabled. In that case,
+        // chrome.extension.connect logs a console error when we try
+        // to reconnect and this code fails. Putting a try/catch around
+        // it didn't help. It's ok to fail if we really don't have a port.
+        port = chrome.extension.connect({name: 'content-script'});
+        port.postMessage(msg);
     }
 };
 

--- a/content.js
+++ b/content.js
@@ -3,7 +3,7 @@ var port = chrome.extension.connect({name: 'content-script'});
 var postMessage = function(msg, attempt){
     attempt = attempt || 1;
     if (attempt > 10){
-        console.log('Could not send messageg after 10 attempts. Giving up.');
+        console.log('Could not send message after 10 attempts. Giving up.');
         console.log(msg);
         return;
     }

--- a/fancy-settings/i18n.js
+++ b/fancy-settings/i18n.js
@@ -40,7 +40,7 @@ this.i18n = {
         'en': 'Valid:'
     },
     'valid description': {
-        'en': '<img id="credentials-valid-img" src="../booleanFalse.png"/> <span id="credentials-valid-text">x</span>'
+        'en': '<img id="credentials-valid-img" src="../booleanFalse.png"/> <span id="credentials-valid-text">This red cross will be replace by a green tick  when your credentials are correct.</span>'
     },
     'description': {
         'en':

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.3.33",
+  "version": "1.3.34",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.3.35",
+  "version": "1.3.44",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.3.34",
+  "version": "1.3.35",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.3.22",
+  "version": "1.3.33",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",


### PR DESCRIPTION
paparent:**approve**

Add simplistic retrying of sending messages to the background script. Now when an extension is disabled, existing tabs will get a port error when trying to send their next message and will essentially deactivate themselves. The background script will inject the content script into all tabs, and this will open a connection to the background script, as normal.

End result is that enabling/disabling installing/uninstalling the extension does the right thing with all existing and new tabs. No need to reload pages to make sure they are connected to an updated or new extension.

Fixes #48
