### PR TITLE
anonymize-lookups-56

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ FOLLOW
 
 In the context menu for the page, over a link or image, or with text selected, you can choose to follow that thing in Fluidinfo. You can follow anything at all: names, @names, URLs, domains, images, words or phrases, anything!
 
+PRIVACY
+-------
+
+No identifying information is sent to Fluidinfo during normal browsing.  The extension makes requests to Fluidinfo with your username *only* to read information you have already stored, or to add new information when you ask it to.  All calls to Fluidinfo are encrypted and we do not log IP addresses. The extension source code is available for download and inspection at https://github.com/fluidinfo/obrowser-chrome-extension
+
 FEEDBACK
 --------
 
@@ -60,13 +65,9 @@ The Fluidinfo Team
 Install from the Chrome store
 -----------------------------
 
-You can install the extension most easily by visiting
-https://chrome.google.com/webstore/detail/eilipheemcfeoafinogpabomclpejioj
-and clicking 'Add to Chrome'.
+You can install the extension most easily by visiting https://chrome.google.com/webstore/detail/eilipheemcfeoafinogpabomclpejioj and clicking 'Add to Chrome'.
 
 Installing from source as an unpacked Chrome extension
 ------------------------------------------------------
 
-Visit `chrome://extensions`, turn on Developer Mode, and click `Load
-unpacked extension`. Then navigate to the directory of this extension and
-Chrome will do the rest.
+Visit `chrome://extensions`, turn on Developer Mode, and click `Load unpacked extension`. Then navigate to the directory of this extension and Chrome will do the rest.

--- a/background.js
+++ b/background.js
@@ -18,6 +18,8 @@ var settings = new Store('settings', {
     'notificationTimeout': 30
 });
 
+var anonFluidinfoAPI = fluidinfo();
+
 var fluidinfoAPI = null;
 var fluidinfoUsername = null;
 
@@ -817,8 +819,11 @@ var displayNotifications = function(options){
         showFolloweeTags(result);
     };
 
-    // Pull back tag paths on the object for the current about value.
-    fluidinfoAPI.api.get({
+    // Pull back tag paths on the object for the current about value. Do
+    // this as the anonymous user to make sure we don't send identifying
+    // info with lookups. Only publicly readable tags will be returned as
+    // a result.
+    anonFluidinfoAPI.api.get({
         path: ['about', valueUtils.lowercaseAboutValue(about)],
         onError: onError,
         onSuccess: onSuccess

--- a/fancy-settings/i18n.js
+++ b/fancy-settings/i18n.js
@@ -103,6 +103,15 @@ this.i18n = {
             'you\'ll see something like: <img src="omnibox-shake-shack.png"></li>' +
             '</ul> '
     },
+    'privacy description': {
+        'en': 'No identifying information is sent to Fluidinfo during normal browsing. ' +
+              'The extension makes requests to Fluidinfo with your username ' +
+              '<em>only</em> to read information you have already stored, or to add new ' +
+              'information when you ask it to. ' +
+              'All calls to Fluidinfo are encrypted and we do not log IP addresses. ' +
+              '<a href="https://github.com/fluidinfo/obrowser-chrome-extension">The extension source code</a> ' +
+              'is available for download and inspection.'
+    },
     'feedback description': {
         'en': 'We\'d love to hear what you think and to improve the extension based on your suggestions. ' +
               'You can mail us at <a href="mailto:info@fluidinfo.com">info@fluidinfo.com</a> or come hang ' +
@@ -113,7 +122,7 @@ this.i18n = {
         'en':
             '<p>' +
             'You\'ll need a Fluidinfo account, including a password, for adding ' +
-            'info to URLs with the extension. The easiest way to set a ' +
+            'info with the extension. The easiest way to set a ' +
             'password, depends on whether you\'ve used fluidinfo.com in the ' +
             'past. Pick one of the following scenarios: ' +
             '</p>' +
@@ -137,7 +146,7 @@ this.i18n = {
 
             '<li>' +
             'If you already have a Fluidinfo account that you created ' +
-            'manually (i.e., without using Twitter login): ' +
+            'manually (i.e., not using Twitter login): ' +
             '<a href="https://fluidinfo.com/accounts/settings/">set your password</a>.' +
             '</li>' +
 

--- a/fancy-settings/manifest.js
+++ b/fancy-settings/manifest.js
@@ -82,6 +82,13 @@ this.manifest = {
         },
         {
             'tab': i18n.get('help'),
+            'group': i18n.get('Privacy'),
+            'name': 'privacy',
+            'type': 'description',
+            'text': i18n.get('privacy description')
+        },
+        {
+            'tab': i18n.get('help'),
             'group': i18n.get('Feedback'),
             'name': 'feedback',
             'type': 'description',

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.3.77",
+  "version": "1.3.82",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",


### PR DESCRIPTION
Make GET calls for tags on the current object anonymous. Update README and options help docs with a privacy section.

Fixes #56
