### PR TITLE
add-domain-from-current-URL-to-context-menu-for-following-58

### DIFF
--- a/background.js
+++ b/background.js
@@ -175,7 +175,7 @@ var absoluteHref = function(linkURL, docURL){
 // the menu item index returned by chrome.contextMenus.create.
 var contextMenuItems = {};
 
-var addContextMenuItem = function(text, type, context){
+var addContextMenuItem = function(text, context){
     // Add (possibly truncated) 'text' to the context menu, if not already present.
     text = (text.length < 50 ? text : text.slice(0, 47) + '...').replace(/\n+/g, ' ');
 
@@ -240,7 +240,7 @@ chrome.extension.onConnect.addListener(function(port){
                 if (currentSelection === null || msg.selection !== currentSelection){
                     currentSelection = msg.selection;
                     removeContextMenuItemsByContext('selection');
-                    addContextMenuItem(currentSelection, 'selection', 'selection');
+                    addContextMenuItem(currentSelection, 'selection');
                     if (currentSelection.length < maxSelectionLengthToLookup){
                         createSelectionNotifications(currentSelection);
                     }
@@ -269,7 +269,7 @@ chrome.extension.onConnect.addListener(function(port){
                 // There are <a> tags with no href in them.
                 if (msg.linkURL){
                     var url = absoluteHref(msg.linkURL, msg.docURL);
-                    addContextMenuItem(url, 'url', 'link');
+                    addContextMenuItem(url, 'link');
                 }
 
                 // And there are <a> tags with no text in them.
@@ -284,7 +284,7 @@ chrome.extension.onConnect.addListener(function(port){
                             var lower = name.toLowerCase();
                             if (lower !== 'following' && lower !== 'followers'){
                                 // Update with @name
-                                addContextMenuItem('@' + name, 'link-text', 'link');
+                                addContextMenuItem('@' + name, 'link');
 
                                 // Look for "fullname @username" text.
                                 var spaceAt = msg.text.indexOf(' @');
@@ -295,14 +295,14 @@ chrome.extension.onConnect.addListener(function(port){
                                     // will take you to something ending in %E2%80%8F (the UTF-8
                                     // for that codepoint).
                                     var fullname = msg.text.slice(0, spaceAt).replace(/^\s+|[\s\u200F]+$/g, '');
-                                    addContextMenuItem(fullname, 'link-text', 'link');
+                                    addContextMenuItem(fullname, 'link');
                                 }
                             }
 
                             return;
                         }
                     }
-                    addContextMenuItem(msg.text, 'link-text', 'link');
+                    addContextMenuItem(msg.text, 'link');
                 }
             }
             else {
@@ -846,6 +846,13 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
             updateBadge: true
         });
     }
+});
+
+chrome.tabs.onActiveChanged.addListener(function(tabId, selectInfo){
+    removeContextMenuItemsByContext('page');
+    chrome.tabs.get(tabId, function(tab){
+        addContextMenuItem(valueUtils.extractDomainFromURL(tab.url), 'page');
+    });
 });
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.3.93",
+  "version": "1.3.94",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.3.82",
+  "version": "1.3.85",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.3.85",
+  "version": "1.3.93",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/values.js
+++ b/values.js
@@ -37,6 +37,43 @@ var valueUtils = {
             return str.toLowerCase();
         }
     },
+    extractDomainFromURL: function(str){
+        var domain = str;
+        var match = this.uriRegex.exec(str);
+        if (match){
+            var postScheme = match[2];
+            var hostport;
+            var slash = postScheme.indexOf('/');
+
+            if (slash > -1){
+                var hierarchicalPart = postScheme.slice(0, slash);
+            }
+            else {
+                var hierarchicalPart = postScheme;
+            }
+
+            if (hierarchicalPart){
+                var at = hierarchicalPart.indexOf('@');
+                if (at > -1){
+                    hostport = hierarchicalPart.slice(at + 1);
+                }
+                else {
+                    hostport = hierarchicalPart;
+                }
+
+                if (hostport){
+                    var colon = hostport.indexOf(':');
+                    if (colon > -1){
+                        domain = hostport.slice(0, colon);
+                    }
+                    else {
+                        domain = hostport;
+                    }
+                }
+            }
+        }
+        return domain;
+    },
     truncateAbout: function(about, maxLen){
         // Return a shortened form of 'about' of length at most maxLen, suitable
         // for display.

--- a/values.js
+++ b/values.js
@@ -37,9 +37,9 @@ var valueUtils = {
             return str.toLowerCase();
         }
     },
-    extractDomainFromURL: function(str){
-        var domain = str;
-        var match = this.uriRegex.exec(str);
+    extractDomainFromURL: function(url){
+        var domain = url;
+        var match = this.uriRegex.exec(url);
         if (match){
             var postScheme = match[2];
             var hostport;

--- a/values.js
+++ b/values.js
@@ -74,6 +74,10 @@ var valueUtils = {
         }
         return domain;
     },
+    isChromeURL: function(url){
+        return url.slice(0, 9) === 'chrome://' || url.slice(0, 18) === 'chrome-devtools://';
+
+    },
     truncateAbout: function(about, maxLen){
         // Return a shortened form of 'about' of length at most maxLen, suitable
         // for display.

--- a/values.js
+++ b/values.js
@@ -76,7 +76,6 @@ var valueUtils = {
     },
     isChromeURL: function(url){
         return url.slice(0, 9) === 'chrome://' || url.slice(0, 18) === 'chrome-devtools://';
-
     },
     truncateAbout: function(about, maxLen){
         // Return a shortened form of 'about' of length at most maxLen, suitable


### PR DESCRIPTION
ceronman:**approve with comment**

Add follow/goto the page URL's domain to the context menu. Removed passing of unused arg to addContextMenuItem.

Fixes #58
