### PR TITLE
sidebar-close-via-X-image-74

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,9 +7,8 @@ var currentSelection = null;
 var tabThatCreatedCurrentSelection = null;
 var maxSelectionLengthToLookup = 200;
 
-// Things we consider as possibly being an about value that's a
-// corresponds to something that's being followed, e.g.,
-// '@username' or 'wordnik.com'.
+// Things we consider as possibly being an about value that corresponds to
+// something that's being followed, e.g., '@username' or 'wordnik.com'.
 var followeeRegex = /^@?([\w\.]+)$/;
 
 // -----------------  Settings, creds, Fluidinfo API -----------------
@@ -403,6 +402,12 @@ chrome.extension.onRequest.addListener(
         }
         else if (request.action === 'get-settings'){
             sendResponse(settings.toObject());
+        }
+        else if (request.action === 'update-current-tab-url'){
+            // TODO: use me from the sidebar iframe.
+            chrome.tabs.update(sender.tab.id, {
+                url: request.url
+            });
         }
         else if (request.action === 'validate-credentials'){
             validateCredentials({

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.4.148",
+  "version": "1.4.232",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.4.232",
+  "version": "1.4.244",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/sidebar-inject.js
+++ b/sidebar-inject.js
@@ -1,0 +1,46 @@
+/*
+ * This script is injected into all frames of a tab when the sidebar has
+ * been created. It should only do things if it's in the sidebar frame, not
+ * in the main tab code.
+ */
+
+var close = document.getElementById('close');
+
+if (close){
+    var port = chrome.extension.connect({
+        name: 'sidebar-iframe'
+    });
+    
+    close.style.display = 'inline';
+
+    close.addEventListener(
+        'click',
+        function(evt){
+            port.postMessage({
+                action: 'hide sidebar'
+            });
+            return false;
+        },
+        false
+    );
+    
+    document.getElementsByTagName('body')[0].addEventListener(
+        'click',
+        function(evt){
+            // Intercept click events on links and send a message to the
+            // background page so they can be displayed in the current tab.
+            if (evt.target.nodeName === 'A'){
+                port.postMessage({
+                    action: 'open',
+                    docURL: document.location.toString(),
+                    linkURL: evt.target.getAttribute('href')
+                });
+                evt.preventDefault();
+                evt.stopPropagation();
+                return false;
+            }
+            return true;
+        },
+        true
+    );
+}

--- a/sidebar.css
+++ b/sidebar.css
@@ -11,10 +11,20 @@
 
 .sidebar.right {
     border-left: 1px solid #ccc;
+    box-shadow: -2px 0px 1px 1px rgba(0, 0, 0, 0.2);
     right: 0;
 }
 
 .sidebar.left {
     border-right: 1px solid #ccc;
+    box-shadow: 2px 0px 1px 1px rgba(0, 0, 0, 0.2);
     left: 0;
+}
+
+/* This is for the extension X (close sidebar) image. */
+#close {
+    float: right;
+    height: 32px;
+    margin-right: 6px;
+    width: 32px;
 }


### PR DESCRIPTION
jkakar:**approve**

This branch turned out to be misnamed. It doesn't seem to be possible to add event handlers to the iframe that's created on the pages we add the iframe to. It looks like we'll need to deliver JS to do that sort of thing from the extension endpoint on fluidinfo.com so that it's loaded by the iframe.

Fixes #74
