### PR TITLE
add-link-to-notification-popup-to-open-sidebar-84

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.5.4",
+  "version": "1.5.9",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/notification.html
+++ b/notification.html
@@ -29,6 +29,7 @@
       <br/>
       <span id="fi_url">URL</span>
       <br/>
+      <a href="#" id="fi_open_sidebar">Open sidebar</a>
     </p>
     <p>
       <div id="fi_tags"></div>

--- a/notification.js
+++ b/notification.js
@@ -14,18 +14,26 @@ var populate = function(options){
     var truncatedAbout = valueUtils.truncateAbout(about, 35);
     var url = 'http://fluidinfo.com/about/#!/' + encodeURIComponent(about);
     
-    // For now, show the sidebar whenever there's something to show.
-    var port = chrome.tabs.connect(options.tabId, {name: 'sidebar'});
-    port.postMessage({
-        about: options.about,
-        action: 'show sidebar'
-    });
-
     document.getElementById('fi_url').innerHTML = Mustache.render(
         '<a href="{{url}}" target="_blank">{{truncatedAbout}}</a>', {
             truncatedAbout: truncatedAbout,
             url: url
         }
+    );
+
+    document.getElementById('fi_open_sidebar').addEventListener(
+        'click',
+        function(evt){
+            var port = chrome.tabs.connect(options.tabId, {name: 'sidebar'});
+            port.postMessage({
+                about: options.about,
+                action: 'show sidebar'
+            });
+            evt.preventDefault();
+            evt.stopPropagation();
+            return false;
+        },
+        false
     );
 
     // Add the HTML for each of the custom prefixes on the object.


### PR DESCRIPTION
jkakar:**approve** sausage:**approve** fsm:**approve**

The popup now has a link to open the sidebar manually.

Fixes #84
