### PR TITLE
fix-close-icon-in-sidebar-92

### DIFF
--- a/iframe.js
+++ b/iframe.js
@@ -27,17 +27,26 @@ if (close){
         function(evt){
             // Intercept click events on links and send a message to the
             // background page so they can be displayed in the current tab.
+            var url = null;
             if (evt.target.nodeName === 'A'){
+                url = evt.target.getAttribute('href');
+            }
+            else if (evt.target.nodeName === 'IMG'){
+                url = evt.target.parentNode.getAttribute('href');
+            }
+            if (url){
                 port.postMessage({
                     action: 'open',
                     docURL: document.location.toString(),
-                    linkURL: evt.target.getAttribute('href')
+                    linkURL: url
                 });
                 evt.preventDefault();
                 evt.stopPropagation();
                 return false;
             }
-            return true;
+            else {
+                return true;
+            }
         },
         true
     );

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.5.40",
+  "version": "1.5.48",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",


### PR DESCRIPTION
paparent:**approved**

I thought the X icon was causing a problem, but it seems it's not. So instead I fixed the issue with clicks on images not opening their parent element href. So now clicking the Fluidinfo logo or your avatar navigates the tab to the right place.

Fixes #92
