### PR TITLE
stop-using-new.fluidinfo.com-96

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fluidinfo",
-  "version": "1.5.40",
+  "version": "1.5.52",
   "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",

--- a/sidebar.js
+++ b/sidebar.js
@@ -4,7 +4,7 @@
  * testing, 'new.fluidinfo.com' for the staging server, and 'fluidinfo.com'
  * for extension deployments to the Chrome store.
  */
-var infomaniacHost = 'new.fluidinfo.com';
+var infomaniacHost = 'fluidinfo.com';
 
 var settings = null;
 


### PR DESCRIPTION
paparent:**approved**

NOTE: don't merge until fluidinfo.com can serve the infomaniac sidebar content correctly.

TRIVIAL: Move to fi.com from new.fi.com

Fixes #96
