### PR TITLE
widen-sidebar-on-twitter-login-105

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,28 @@ zip:
 
 clean:
 	find . -name '*~' | xargs -r rm
-	rm fluidinfo-extension.zip
+	rm -f fluidinfo-extension.zip
+
+wc:
+	@wc -l \
+	    background.js \
+	    content.js \
+	    context.js \
+	    domains/domains.js \
+	    domains/oreilly.com.js \
+	    domains/parse.js \
+	    domains/radar.oreilly.com.js \
+	    domains/sportsdirect.com.js \
+	    domains/telegraph.co.uk.js \
+	    fancy-settings/i18n.js \
+	    fancy-settings/manifest.js \
+	    fancy-settings/settings.js \
+	    fluidinfo.js \
+	    global.js \
+	    iframe.js \
+	    notification.js \
+	    omnibox.js \
+	    shortcut.js \
+	    sidebar.js \
+	    tagValueHandler.js \
+	    values.js

--- a/background.html
+++ b/background.html
@@ -15,6 +15,7 @@
     <script type="text/javascript" src="domains/sportsdirect.com.js"></script>
     <script type="text/javascript" src="domains/telegraph.co.uk.js"></script>
     <script type="text/javascript" src="domains/domains.js"></script>
+    <script type="text/javascript" src="global.js"></script>
     <script type="text/javascript" src="omnibox.js"></script>
     <script type="text/javascript" src="context.js"></script>
     <script type="text/javascript" src="background.js"></script>

--- a/global.js
+++ b/global.js
@@ -1,0 +1,11 @@
+/*
+ * fluidinfoHost is the hostname (possibly with a port) where the
+ * fluidinfo.com site is running.  That is where we'll load sidebar content
+ * from, and where we'll send users to when they want to see something on
+ * our site.
+ * 
+ * Use 'localhost:8000' for local testing, 'new.fluidinfo.com' for the
+ * staging server, and 'fluidinfo.com' when deploying to the Chrome store.
+ */
+
+var fluidinfoHost = 'new.fluidinfo.com';

--- a/iframe.js
+++ b/iframe.js
@@ -11,6 +11,16 @@ if (close){
         name: 'sidebar-iframe'
     });
 
+    // Listen for requests from the background page.
+    port.onMessage.addListener(function(msg) {
+        if (msg.action === 'reload'){
+            window.location.reload();
+        }
+        else {
+            console.log('iframe received unrecognized message from background: ', msg);
+        }
+    });
+
     close.addEventListener(
         'click',
         function(evt){
@@ -33,8 +43,21 @@ if (close){
             }
             else if (evt.target.nodeName === 'IMG'){
                 url = evt.target.parentNode.getAttribute('href');
+                if (url && url.slice(0, 17) === '/login/fluidinfo/'){
+                    // The user is trying to log in. Ask the background
+                    // page to start that process (we can't do it here as
+                    // we're just a lowly iframe).
+                    port.postMessage({
+                        action: 'oauth login'
+                    });
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    return false;
+                }
             }
             if (url){
+                // Ask the background page to open the link in the tab that
+                // created us.
                 port.postMessage({
                     action: 'open',
                     docURL: document.location.toString(),

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Fluidinfo",
-  "version": "1.5.60",
-  "description": "Add your info to URLs, and jump to Fluidinfo pages for them and for selected text.",
+  "version": "1.5.101",
+  "description": "Talk about the page you're looking at or the text you have selected in a sidebar.",
   "omnibox": { "keyword" : "fi" },
   "background_page": "background.html",
   "options_page": "fancy-settings/settings.html",
@@ -27,7 +27,7 @@
   "content_scripts": [
     {
       "css": ["sidebar.css"],
-      "js": ["shortcut.js", "jquery-1.7.1.min.js", "values.js", "sidebar.js"],
+      "js": ["shortcut.js", "jquery-1.7.1.min.js", "global.js", "values.js", "sidebar.js"],
       "matches": ["<all_urls>"],
       "run_at": "document_start"
     },

--- a/notification.html
+++ b/notification.html
@@ -13,6 +13,7 @@
     <link type="text/css" rel="stylesheet" href="domains/telegraph.co.uk.css"/>
     <script type="text/javascript" src="jquery-1.7.1.min.js"></script>
     <script type="text/javascript" src="mustache.js"></script>
+    <script type="text/javascript" src="global.js"></script>
     <script type="text/javascript" src="values.js"></script>
     <script type="text/javascript" src="domains/parse.js"></script>
     <script type="text/javascript" src="domains/oreilly.com.js"></script>

--- a/notification.html
+++ b/notification.html
@@ -23,7 +23,7 @@
     <script type="text/javascript" src="notification.js"></script>
   </head>
   <body>
-    <img id="logo" src="images/fi_19.png"/>
+    <img id="logo" src="images/fi-19.png"/>
     <p id="fi_notification_intro">
       <span id="fi_title">People you follow have added info to</span>:<br/>
       <span id="fi_url">URL</span>.

--- a/notification.js
+++ b/notification.js
@@ -12,7 +12,7 @@ var populate = function(options){
      */
     var about = options.about;
     var truncatedAbout = valueUtils.truncateAbout(about, 35);
-    var url = 'http://fluidinfo.com/about/' + encodeURIComponent(about);
+    var url = 'http://' + fluidinfoHost + '/about/' + encodeURIComponent(about);
     
     document.getElementById('fi_url').innerHTML = Mustache.render(
         '<a href="{{url}}" target="_blank">{{truncatedAbout}}</a>.', {

--- a/sidebar.js
+++ b/sidebar.js
@@ -1,11 +1,3 @@
-/*
- * infomaniacHost is the hostname (possibly with a colon & port) from which
- * to load sidebar content in an iframe. Use 'localhost:8000' for local
- * testing, 'new.fluidinfo.com' for the staging server, and 'fluidinfo.com'
- * for extension deployments to the Chrome store.
- */
-var infomaniacHost = 'new.fluidinfo.com';
-
 var settings = null;
 
 var backgroundPort = chrome.extension.connect({
@@ -33,7 +25,7 @@ var getSidebar = function(){
 };
 
 var updateSidebar = function(sidebar, about, callback){
-    sidebar.src = 'http://' + infomaniacHost + '/infomaniac/' + encodeURIComponent(about);
+    sidebar.src = 'http://' + fluidinfoHost + '/infomaniac/' + encodeURIComponent(about);
     sidebar.onload = function(){
         backgroundPort.postMessage({injectSidebarJS: true});
         callback();


### PR DESCRIPTION
This ticket is misnamed, as it started out as an attempt to allow OAuth login in the sidebar. That turns out to be impossible (see comment in ticket as for why).

This branch instead implements OAuth login in a separate tab. When you click log in, the tab opens, you click authorize, the tab is closed, and you're returned to the page you were looking at. The sidebar updates in the tab you were looking at so that you see the logged-in view (it currently hides itself and then slides out again. I've not looked at why, will in another ticket).  I tried to make this work in a separate pop-up window, but that was giving me trouble (I don't remember the details) and would, I think, be subject to pop-up blocking.

If you deny the authorization, the tab that was opened lives on, allowing the user to go wherever they want in it (Twitter offers several options as to where the user might want to go next).

I also did a little clean-up so that the extension just has one variable holding the hostname of the fluidinfo.com site that's in use, and so we can run against a different fluiddb instance too if required.

Let me know if you need help in testing.

Fixes #105
